### PR TITLE
Feat:: Implementação de classe utilitária para padrão Observer

### DIFF
--- a/shared/lib/src/utils/classes/pubsub/PubSub.ts
+++ b/shared/lib/src/utils/classes/pubsub/PubSub.ts
@@ -1,0 +1,139 @@
+/**
+ * @category Utility Class
+ * @module PubSub
+ */
+
+/** Types */
+import {
+  GenericCallbackFunction,
+  CallbackMap,
+} from '../../../data/types/CommonTypes';
+
+/** Errors */
+import { PubSubError } from './PubSubErrors';
+
+/**
+ * Class that enables implementation of publish/subscribe design pattern.
+ */
+export class PubSub {
+  #subscriptions: Map<string, CallbackMap>;
+  #lastSubscriptionId: number;
+
+  constructor() {
+    this.#subscriptions = new Map<string, CallbackMap>();
+    this.#lastSubscriptionId = 0;
+  }
+
+  /**
+   * Checks if the provided event name is valid and throws PubSubError if it is
+   * invalid.
+   *
+   * @param eventName - Event name to be checked
+   *
+   * @throws {@link PubSubError}
+   */
+  #checkEventName(eventName: string): void {
+    if (eventName.length === 0) {
+      throw new PubSubError('Invalid event name');
+    }
+  }
+
+  /**
+   * Checks if the provided callback function is valid and throws PubSubError if
+   * it is invalid.
+   *
+   * @param callback - Function to be checked
+   *
+   * @throws {@link PubSubError}
+   */
+  #checkCallbackFunction(callback: GenericCallbackFunction): void {
+    if (typeof callback !== 'function') {
+      throw new PubSubError('Invalid callback function');
+    }
+  }
+
+  /**
+   * Handles unsubscription for the provided event name and callback function.
+   *
+   * @param eventName - Event name for the registered callback
+   * @param callback - Function to have its subscription removed
+   */
+  #unsubscribeCallback(
+    eventName: string,
+    callback: GenericCallbackFunction
+  ): void {
+    const callbacks: CallbackMap | undefined =
+      this.#subscriptions.get(eventName);
+    if (callbacks) {
+      callbacks.forEach((subscriptionCallback, subscriptionId) => {
+        if (subscriptionCallback === callback) {
+          callbacks.delete(subscriptionId);
+        }
+      });
+    }
+  }
+
+  /**
+   * Adds a subscription callback for the provided event name.
+   *
+   * @sealed
+   * @param eventName - Event name that will trigger the callback
+   * @param callback - Function to be executed when event is published
+   */
+  subscribe(eventName: string, callback: GenericCallbackFunction): void {
+    this.#checkEventName(eventName);
+    this.#checkCallbackFunction(callback);
+    const subscriptionId = `subscription_${this.#lastSubscriptionId++}`;
+    const callbacks: CallbackMap =
+      this.#subscriptions.get(eventName) ||
+      new Map<string, GenericCallbackFunction>();
+    callbacks.set(subscriptionId, callback);
+    this.#subscriptions.set(eventName, callbacks);
+  }
+
+  /**
+   * Removes subscription callback(s) for the provided event name.
+   *
+   * If callback not provided, all the callbacks for the provided event name
+   * will be removed.
+   *
+   * @sealed
+   * @param eventName - Event name for the registered callback
+   * @param callback - Function to have its subscription removed
+   */
+  unsubscribe(eventName: string): void;
+  unsubscribe(eventName: string, callback: GenericCallbackFunction): void;
+  unsubscribe(eventName: string, callback?: GenericCallbackFunction): void {
+    if (!callback) {
+      this.#subscriptions.delete(eventName);
+    } else {
+      this.#unsubscribeCallback(eventName, callback);
+    }
+  }
+
+  /**
+   * Trigger all registered subscription callbacks for a specific event name.
+   *
+   * @sealed
+   * @param eventName - Event name to trigger subscriptions from
+   * @param payload - Payload to be passed to the callback function
+   */
+  publish(eventName: string, ...payload: unknown[]): void {
+    this.#checkEventName(eventName);
+    const callbacks: CallbackMap =
+      this.#subscriptions.get(eventName) ||
+      new Map<string, GenericCallbackFunction>();
+    callbacks.forEach((callback) => {
+      callback(...payload);
+    });
+  }
+
+  /**
+   * Clears all subscriptions for this instance.
+   *
+   * @sealed
+   */
+  unsubscribeFromAll(): void {
+    this.#subscriptions.clear();
+  }
+}

--- a/shared/lib/src/utils/classes/pubsub/PubSubErrors.ts
+++ b/shared/lib/src/utils/classes/pubsub/PubSubErrors.ts
@@ -1,0 +1,15 @@
+/**
+ * @category Utility Class
+ * @module PubSub
+ */
+
+/**
+ * Class which extends the base Error and can be identified as a specific error
+ * related to publish/subscribe design pattern implementation.
+ */
+export class PubSubError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PubSubError';
+  }
+}


### PR DESCRIPTION
# Descrição

As alterações incluem a adição de uma classe util de `PubSub`, que será usada com o propósito de implementar o padrão de Design [Observer](https://refactoring.guru/design-patterns/observer) em outras classes da aplicação que por ventura venham a utilizá-la. E.g `Utils`

Correções # n/da

## Tipo de mudança

- [x] New feature (non-breaking change que adiciona uma funcionalidade)

# Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorrevisão do meu código
- [x] Eu comentei meu código, especialmente em áreas difíceis de entender
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos warnings ou errors
- [ ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [ ] Testes de unitários novos e existentes passam localmente com minhas alterações
- [x] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream
